### PR TITLE
Fix broken redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,12 +4,12 @@ if (!process.env.REDIRECT_URL) {
   throw new Error('You must provide the REDIRECT_URL environment variable!')
 }
 
-const REDIRECT_URL = process.env.REDIRECT_URL.replace(/\/$/, '') + '/'
+const REDIRECT_URL = process.env.REDIRECT_URL
 const STATUS = parseInt(process.env.STATUS, 10) || 301
 const PORT = parseInt(process.env.PORT, 10) || 80
 
 createServer((req, res) => {
-  const Location = `${REDIRECT_URL}${req.url.substr(1)}`
+  const Location = `${REDIRECT_URL}${req.url}`
   res.writeHead(STATUS, { Location })
   res.end()
 }).listen(PORT)

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const STATUS = parseInt(process.env.STATUS, 10) || 301
 const PORT = parseInt(process.env.PORT, 10) || 80
 
 createServer((req, res) => {
-  const Location = `${REDIRECT_URL}${req.url}`
+  const Location = `${REDIRECT_URL}${req.url[1] ? req.url : ''}`
   res.writeHead(STATUS, { Location })
   res.end()
 }).listen(PORT)


### PR DESCRIPTION
Currently users can't redirect to files hosted on certain servers. For example, this file loads fine if you visit it directly:

https://files.webmr.io/_files/shawnpresser@gmail.com/github.com-now-examples-redirect-pull-9-redirection-problem/index.html

But if you try to redirect to it via this repo, it fails with an error:

```
$ now -e REDIRECT_URL=https://files.webmr.io/_files/shawnpresser@gmail.com/github.com-now-examples-redirect-pull-9-redirection-problem/index.html now-examples/redirect
> https://now-redirect-qljxkmwfrv.now.sh [in clipboard] (sfo1) [4s]
```

https://now-redirect-qljxkmwfrv.now.sh fails to load because the final url is `index.html/` instead of `index.html`, causing the server to barf.

I use webmr as my CDN, so this prevents me from redirecting from `foo.mydomain.com` to any index.html hosted on webmr.

This PR solves the problem by appending `req.url` only if it's not a forward slash.

You can test the PR with `now -e REDIRECT_URL=<some-url> shawwn/redirect`

Thanks! Let me know if you have any questions.